### PR TITLE
Add export for VAST plugin

### DIFF
--- a/src/vast-plugin.mjs
+++ b/src/vast-plugin.mjs
@@ -39,7 +39,7 @@ const DEFAULT_OPTIONS = Object.freeze({
 /**
  * VastPlugin
  */
-class VastPlugin extends Plugin {
+export class VastPlugin extends Plugin {
 
   /**
    * Constructor


### PR DESCRIPTION
Add class export so it can be imported and registered in a custom video.js instance.

```
import videojs from "video.js";
...
import {VastPlugin} from "videojsx-vast-plugin/src/vast-plugin.mjs"
videojs.registerPlugin('vast', VastPlugin);
```