### PR TITLE
Fix handling of VPAID's AdClickThru event

### DIFF
--- a/dev/vpaid-html.html
+++ b/dev/vpaid-html.html
@@ -39,8 +39,7 @@
     url: 'http://localhost:9999/vast-vpaid-html.xml',
     skip: 10,
     vpaid: {
-      videoInstance: 'none',
-      iframeUrl: "http://localhost:9999/vpaid-iframe.html"
+      videoInstance: 'none'
     }
   });
 </script>

--- a/dev/vpaid-html.html
+++ b/dev/vpaid-html.html
@@ -39,7 +39,8 @@
     url: 'http://localhost:9999/vast-vpaid-html.xml',
     skip: 10,
     vpaid: {
-      videoInstance: 'none'
+      videoInstance: 'none',
+      iframeUrl: "http://localhost:9999/vpaid-iframe.html"
     }
   });
 </script>

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -49,3 +49,11 @@ export function convertOffsetToSeconds (offsetCode, duration = null) {
 
   return isNaN(result) ? null : result;
 }
+
+export function isString(str) {
+  return typeof str === 'string';
+}
+
+export function isNullishOrBlankString(str) {
+  return str == null || (isString(str) && str.trim().length === 0);
+}


### PR DESCRIPTION
Regarding the AdClickThru event handling, the current behaviour doesn't match the vpaid spec (section 2.5.4 in https://www.iab.com/wp-content/uploads/2015/06/VPAID_2_0_Final_04-10-2012.pdf). This commit fixes this.