### PR TITLE
Rethink creative data

### DIFF
--- a/dev/vast-vpaid-html.xml
+++ b/dev/vast-vpaid-html.xml
@@ -37,7 +37,7 @@
                         </VideoClicks>
                         <AdParameters>
                             <![CDATA[
-                            {"iframeUrl":"http://localhost:9999/vpaid-iframe.html"}
+                            {"iframeUrl":"http://localhost:9999/vpaid-iframe.html","skipTime":10,"duration":"00:00:30"}
                             ]]>
                             </AdParameters>
                         <MediaFiles>

--- a/dev/vpaid-html.html
+++ b/dev/vpaid-html.html
@@ -39,8 +39,7 @@
     url: 'http://localhost:9999/vast-vpaid-html.xml',
     skip: 10,
     vpaid: {
-      videoInstance: 'none',
-      iframeUrl: "http://localhost:9999/vpaid-iframe.html"
+      videoInstance: 'none'
     }
   });
 </script>

--- a/dev/vpaid-html.js
+++ b/dev/vpaid-html.js
@@ -18,7 +18,7 @@ var VpaidHtmlPlayer = function() {
     'remainingTime': 30,
     'skippableState': false,
     'skipTime': 0,
-    'clickUrl': 'about:blank',
+    'clickUrl': null,
     'viewMode': 'normal',
     'width': 0,
     'volume': 1.0
@@ -52,21 +52,15 @@ VpaidHtmlPlayer.prototype.initAd = function(width, height, viewMode, desiredBitr
   try {
     this.parameters_ = JSON.parse(creativeData['AdParameters']);
 
-    if (creativeData.Duration) {
-      this.attributes_['duration'] = creativeData.Duration;
-      this.callEvent_('AdDurationChange');
-    }
-
     if (this.parameters_.duration) {
       this.attributes_['duration'] = this.parseDuration(this.parameters_.duration);
       this.callEvent_('AdDurationChange');
     }
-    if (creativeData.SkipTime) {
-      this.attributes_['skipTime'] = creativeData.SkipTime;
+    if (this.parameters_.skipTime) {
+      this.attributes_['skipTime'] = parseInt(this.parameters_.skipTime);
     }
-
-    if (creativeData.ClickURL) {
-      this.attributes_['clickUrl'] = creativeData.ClickURL;
+    if (this.parameters_.clickUrl) {
+      this.attributes_['clickUrl'] = this.parameters_.clickUrl;
     }
   } catch (e) {
     console.error('Error parsing AdParameters:', e);

--- a/src/vpaid-handler.mjs
+++ b/src/vpaid-handler.mjs
@@ -138,12 +138,7 @@ export class VPAIDHandler {
           }
 
           const creativeData = {
-            AdParameters: creative.adParameters || '',
-            Duration: creative.duration || 30,
-            SkipTime: options.skip,
-            ClickURL: creative.videoClickThroughURLTemplate?.url || 'about:blank',
-            All: creative,
-            Options: options,
+            AdParameters: creative.adParameters || ''
           };
 
           const videoInstance = options.vpaid.videoInstance;


### PR DESCRIPTION
There are problems regarding the fields we set on VPAID's creativeData.

* The extra fields are not industry standard. In other words, not all players provide them. Only `AdParameters` is standard. 
* The `All` and `Options` exposes implementation details. Can't change them without affecting the vpaid creatives.

I propose getting the clickUrl, skipTime and duration from the `AdParameters` (via VAST XML). Since the creative (e.g. vpaid-html.js) comes from the adserver, it makes sense that its parameters also come from the same adserver (the source of the VAST). I've made changes to vpaid-html.js and vpaid-handler.js demonstrating this.

The `skipTime` does not need to use the player's `options.skipTime`. VPAID creative can use its own setting. In other words, they can take as long as they like. The player can intervene and put its own skip button on using `options.skipTime` (but we won't do that). NOTE: if it makes it easier, you can use the same name VAST spec uses: `skipoffset` which has a value format of either XX% or HH:MM:SS.

You don't have to provide `clickUrl`. You can ask the player when firing the AdClickThru event to do the job. By passing in `null` for the url (see code). So it can be optional (doesn't need to be on AdParameters). PR related to this: https://github.com/philipwatson/videojsx-vast-plugin/pull/55