### PR TITLE
Fix & simplify VPAID container handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,10 @@ Example:
 
 ##### VPAID Options
 
-| Name               | Optional | Default                 | Description                                                                                         |
-|--------------------|----------|-------------------------|-----------------------------------------------------------------------------------------------------|
-| `videoInstance`    | Yes      | `'none'`                | Determines which video element to pass to the VPAID ad. Any one of: `'none'`, `'new'` and `'same'`. |
-| `containerId`      | Yes      | `undefined`             | The id of the container. Usage is not recommended.                                                  |
-| `containerllClass` | Yes      | `'vjs-vpaid-container'` | The class name of the container. Usage is not recommended.                                          |
+| Name              | Optional | Default                 | Description                                                                          |
+|-------------------|----------|-------------------------|--------------------------------------------------------------------------------------|
+| `videoInstance`   | Yes      | `'same'`                | Determines which video element to pass to the VPAID ad. Either `'none'` or `'same'`. |
+| `containerClass`  | Yes      | `'vjs-vpaid-container'` | The class name of the container that will house the VPAID iframe.                    |
 
 ##### Schedule Item Options
 

--- a/dev/vpaid-iframe.html
+++ b/dev/vpaid-iframe.html
@@ -60,7 +60,7 @@
     <script>
         function sendMessage(eventName) {
             console.log('[IFRAME][sendMessage] Sending message from iframe:', eventName);
-            window.parent[0].postMessage({type: 'vpaid', event: eventName}, '*');
+            window.parent.postMessage({type: 'vpaid', event: eventName}, '*');
         }
 
         document.getElementById('clickThrough').addEventListener('click', function() {

--- a/dev/vpaid.html
+++ b/dev/vpaid.html
@@ -28,7 +28,6 @@
   player.vast({
     url: 'http://localhost:9999/vast-vpaid.xml',
     vpaid: {
-      containerId: 'player-vast-container',
       videoInstance: 'none'
     }
   });

--- a/src/vast-plugin.mjs
+++ b/src/vast-plugin.mjs
@@ -24,7 +24,6 @@ const DEFAULT_OPTIONS = Object.freeze({
     remainingTime: 'This ad will end in {seconds}',
   },
   vpaid: {
-    containerId: undefined,
     containerClass: 'vjs-vpaid-container',
     videoInstance: 'none'
   },


### PR DESCRIPTION
I misunderstood the VPAIDHTML5Client constructor:

```
function VPAIDHTML5Client(el, video, templateConfig, vpaidOptions)
```

I thought the `el` param = VPAID environmentVars slot. This not the case. The `el` is the element that will contain VPAID's friendly iframe. 

This misunderstanding cause some issues with some ad units (creatives):

* Click-through not working
* Ad unit's video element, when no width or height, being bigger than desired. Because it relied on an iframe to constrain its size.

The VPAIDHTML5Client will create the slot element inside this iframe and will set `environmentVars.slot` for us. We just have to worry about putting the `el` in the right place and passing it into VPAIDHTML5Client. And optionally pass in `video`. 

I also simplified things:

* Drop `new` support for `videoInstance`. Because where do we put it? On the main page where video.js is (no iframe)? No, things will break as mentioned above. Put it inside the iframe that is managed by VPAIDHTML5Client? No, it is not possible because VPAIDHTML5Client provides no api for this. Perhaps there is a hacky way, but that isn't great either. Usually vpaid adunits create their own video element. And personally never seen an adunit use the provided video element (when `videoInstance` is `same` or `new`). If there is a strong need for `new` then I'll revisit this.
* Drop the `containerId` config. Only need `containerClass` config. 
* The plugin is responsible for creating and destroying the vpaid container (the `el` element mentioned above). We don't want the user doing this. So we can simplify the cleanup code: we don't have to remember stuff in order to restore things as they were before.
* Don't need to set `environmentVars.slot` and `environmentVars.videoSlot`. VPAIDHTML5Client does this for us.
