### PR TITLE
Add mute toggle button for VPAID

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,12 @@ Example:
 
 ##### VPAID Options
 
-| Name              | Optional | Default                 | Description                                                                          |
-|-------------------|----------|-------------------------|--------------------------------------------------------------------------------------|
-| `videoInstance`   | Yes      | `'same'`                | Determines which video element to pass to the VPAID ad. Either `'none'` or `'same'`. |
-| `containerClass`  | Yes      | `'vjs-vpaid-container'` | The class name of the container that will house the VPAID iframe.                    |
+| Name               | Optional | Default                 | Description                                                                                                    |
+|--------------------|----------|-------------------------|----------------------------------------------------------------------------------------------------------------|
+| `videoInstance`    | Yes      | `'same'`                | Determines which video element to pass to the VPAID ad. Either `'none'` or `'same'`.                           |
+| `containerClass`   | Yes      | `'vjs-vpaid-container'` | The class name of the container that will house the VPAID iframe.                                              |
+| `enableToggleMute` | Yes      | `false`                 | Show a transparent icon button on the video (bottom-right) that the user can use to mute and unmute the audio. |   
+
 
 ##### Schedule Item Options
 

--- a/dev/vpaid.html
+++ b/dev/vpaid.html
@@ -28,7 +28,8 @@
   player.vast({
     url: 'http://localhost:9999/vast-vpaid.xml',
     vpaid: {
-      videoInstance: 'none'
+      videoInstance: 'none',
+      enableToggleMute: true
     }
   });
 </script>

--- a/dev/vpaidad.js
+++ b/dev/vpaidad.js
@@ -440,6 +440,7 @@ VpaidVideoPlayer.prototype.getAdVolume = function() {
 VpaidVideoPlayer.prototype.setAdVolume = function(value) {
   this.attributes_['volume'] = value;
   this.log('setAdVolume ' + value);
+  this.videoSlot_.volume = value;
   this.callEvent_('AdVolumeChange');
 };
 

--- a/src/vast-player.css
+++ b/src/vast-player.css
@@ -73,3 +73,46 @@ Original @ https://github.com/theonion/videojs-vast-plugin (commit bf6ce85fa7632
     right: 0;
     bottom: 0;
 }
+
+.vpaid-control-bar {
+    width: 100%;
+    position: absolute;
+    height: 4.0em;
+    bottom: 0;
+    left: 0;
+    z-index: 100;
+}
+
+.vpaid-mute:before {
+    font-size: 3.0em;
+    content: "\f104";
+}
+
+.vpaid-unmute:before {
+    font-size: 3.0em;
+    content: "\f107";
+}
+
+.vpaid-toggle-mute-button {
+    text-align: center;
+    position: absolute;
+    bottom: 0.5em;
+    right: 0.5em;
+    cursor: pointer;
+}
+
+.vpaid-icon-placeholder {
+    font-family: VideoJS;
+    text-shadow: 0 0 1px black, 0 0 1px black, 0 0 1px black, 0 0 1px black;
+    font-size: 3.0em;
+    color: #ffffff;
+    opacity: 0.3;
+}
+
+.vpaid-icon-placeholder:before {
+    content: "\f107";
+}
+
+.mute .vpaid-icon-placeholder:before {
+    content: "\f104";
+}

--- a/src/vpaid-handler.mjs
+++ b/src/vpaid-handler.mjs
@@ -13,6 +13,9 @@ export class VPAIDHandler {
   #player
   #options
   #eventTarget
+  #volume
+  #muted
+  #controlBar
 
   constructor(player, options) {
     this.#player = player;
@@ -24,6 +27,8 @@ export class VPAIDHandler {
     this.#cancelled = false;
     this.#started = false
     this.#forceStopDone = false;
+
+    this.setVolume(this.#player.volume());
 
     return new Promise((resolve, reject) => {
       const options = this.#options;
@@ -84,7 +89,8 @@ export class VPAIDHandler {
           return;
         }
 
-        function cleanUp() {
+        const cleanUp = () => {
+          this.removeMuteControl();
           player.controlBar.show();
 
           player.off('playerresize', resizeAd);
@@ -161,9 +167,9 @@ export class VPAIDHandler {
           });
 
           adUnit.subscribe('AdVolumeChange', () => {
-            const lastVolume = player.volume()
             adUnit.getAdVolume((error, currentVolume) => {
               if (error) return;
+              const lastVolume = this.#volume
 
               if (currentVolume === 0 && lastVolume > 0) {
                 tracker.setMuted(true);
@@ -171,7 +177,11 @@ export class VPAIDHandler {
                 tracker.setMuted(false);
               }
 
+              this.setVolume(currentVolume);
+
+              // keep our player in sync
               player.volume(currentVolume);
+
               player.trigger('vpaid.AdVolumeChange');
             });
           });
@@ -269,6 +279,8 @@ export class VPAIDHandler {
           const startLinearAd = () => {
             player.controlBar.hide();
 
+            this.addMuteControl(adUnit);
+
             // A VPAID adunit may (incorrectly?) call AdStarted again for the first quartile event
             const onAdStartedOnce = once(onAdStarted);
             subscribeWithTimeout(adUnit, 'AdStarted', onAdStartedOnce, forceStopAd);
@@ -319,11 +331,67 @@ export class VPAIDHandler {
     });
   }
 
-  // TODO: review. may not need.
+  removeMuteControl() {
+    this.#controlBar?.remove();
+    this.#controlBar = null;
+  }
+
+  addMuteControl(adUnit) {
+    const controlBarDiv = document.createElement('div');
+    controlBarDiv.className = 'vpaid-control-bar';
+
+    this.#controlBar = controlBarDiv;
+
+    const toggleMuteButton = document.createElement('button');
+    toggleMuteButton.type = 'button';
+    toggleMuteButton.className = 'vpaid-toggle-mute-button';
+
+    const toggleMuteSpan = document.createElement('span');
+    toggleMuteSpan.className = 'vpaid-icon-placeholder';
+
+    toggleMuteButton.addEventListener('click', () => {
+      this.#muted = !this.#muted;
+
+      const newVolume = this.#muted ? 0 : (this.#volume || 1);
+
+      adUnit.setAdVolume(newVolume, (/*error, callback*/)=>{});
+
+      // NOTE: the mute icon button will be updated via the AdVolumeChange event (triggered by the adUnit).
+    });
+
+    toggleMuteButton.appendChild(toggleMuteSpan);
+    controlBarDiv.appendChild(toggleMuteButton);
+
+    const player = this.#player;
+
+    player.el().insertBefore(controlBarDiv, player.controlBar.el());
+
+    adUnit.getAdVolume((error, currentVolume) => {
+      if (error) return;
+      this.setVolume(currentVolume);
+    });
+  }
+
+// TODO: review. may not need.
   cancel() {
     this.#cancelled = true;
     if (this.#started) {
       this.#eventTarget.trigger('forceStopAd');
+    }
+  }
+
+  setVolume(v) {
+    this.#volume = v;
+    this.#muted = v === 0;
+    this.updateControlBar();
+  }
+
+  updateControlBar() {
+    if (this.#controlBar != null) {
+      let className = this.#controlBar.className;
+      className = className.replaceAll('mute', '').trim();
+      className += this.#muted ? ' mute' : '';
+      this.#controlBar.className = className;
     }
   }
 }

--- a/src/vpaid-handler.mjs
+++ b/src/vpaid-handler.mjs
@@ -279,7 +279,9 @@ export class VPAIDHandler {
           const startLinearAd = () => {
             player.controlBar.hide();
 
-            this.addMuteControl(adUnit);
+            if (options.vpaid.enableToggleMute) {
+              this.addMuteControl(adUnit);
+            }
 
             // A VPAID adunit may (incorrectly?) call AdStarted again for the first quartile event
             const onAdStartedOnce = once(onAdStarted);


### PR DESCRIPTION
Some VPAID ad units play without sound (most likely due to browser restrictions) and provide no means to enable audio (no mute or volume control). This commit adds an optional button that enables the user to toggle mute volume on and off.